### PR TITLE
Adds COUNT(DISTINCT ...) aggregation

### DIFF
--- a/lib/active_reporting/metric.rb
+++ b/lib/active_reporting/metric.rb
@@ -2,17 +2,18 @@
 
 require 'forwardable'
 module ActiveReporting
-  AGGREGATES = %i[count sum max min avg].freeze
+  AGGREGATES = %i[count sum max min avg count_distinct].freeze
 
   class Metric
     extend Forwardable
     def_delegators :@fact_model, :model
-    attr_reader :fact_model, :name, :dimensions, :dimension_filter, :aggregate, :metric_filter, :order_by_dimension
+    attr_reader :fact_model, :name, :dimensions, :dimension_filter, :aggregate, :distinct_on, :metric_filter, :order_by_dimension
 
     def initialize(
       name,
       fact_model:,
       aggregate: :count,
+      distinct_on: [],
       dimensions: [],
       dimension_filter: {},
       metric_filter: {},
@@ -22,6 +23,7 @@ module ActiveReporting
       @fact_model         = fact_model
       @dimension_filter   = dimension_filter
       @aggregate          = determin_aggregate(aggregate.to_sym)
+      @distinct_on        = distinct_on
       @metric_filter      = metric_filter
       @dimensions         = ReportingDimension.build_from_dimensions(@fact_model, Array(dimensions))
       @order_by_dimension = order_by_dimension

--- a/lib/active_reporting/report.rb
+++ b/lib/active_reporting/report.rb
@@ -80,6 +80,12 @@ module ActiveReporting
       case @metric.aggregate
       when :count
         'COUNT(*)'
+      when :count_distinct
+        columns = @metric.distinct_on
+                         .map { |c| fact_model.model.connection.quote_column_name(c.to_s) }
+                         .join(', ')
+
+        "COUNT(DISTINCT #{columns})"
       else
         "#{@metric.aggregate.to_s.upcase}(#{fact_model.measure})"
       end

--- a/test/active_reporting/metric_test.rb
+++ b/test/active_reporting/metric_test.rb
@@ -18,6 +18,13 @@ class ActiveReporting::MetricTest < Minitest::Test
     assert @metric.dimensions.all?{ |d| d.is_a?(ActiveReporting::ReportingDimension) }
   end
 
+  def test_metric_handles_count_distinct_aggregation
+    metric = ActiveReporting::Metric.new(:a_metric, fact_model: FigureFactModel, aggregate: :count_distinct, distinct_on: [:id])
+
+    assert_equal metric.aggregate, :count_distinct
+    assert_equal metric.distinct_on, [:id]
+  end
+
   def test_metric_raises_if_given_an_unknown_dimension
     assert_raises ActiveReporting::UnknownDimension do
       ActiveReporting::Metric.new(:a_metric, fact_model: FigureFactModel, dimensions: [:invalid])

--- a/test/active_reporting/report_test.rb
+++ b/test/active_reporting/report_test.rb
@@ -32,6 +32,17 @@ class ActiveReporting::ReportTest < Minitest::Test
     assert data.all? { |r| r.key?('a_metric') }
   end
 
+  def test_report_runs_with_count_distinct
+    metric = ActiveReporting::Metric.new(:a_metric, fact_model: SaleFactModel, dimensions: [:item], aggregate: :count_distinct, distinct_on: [:placed_at_id])
+    report = ActiveReporting::Report.new(metric)
+    data   = report.run
+
+    refute data.empty?
+    assert data.all? { |r| r.key?('a_metric') }
+
+    assert_equal report.send(:select_aggregate), 'COUNT(DISTINCT "placed_at_id")'
+  end
+
   def test_report_runs_with_a_date_grouping
     if ['pg','mysql'].include?(ENV['DB'])
       metric = ActiveReporting::Metric.new(:a_metric, fact_model: UserFactModel, dimensions: [{created_at: :month}])


### PR DESCRIPTION
Adds the `COUNT(DISTINCT ...)` aggregation as an option for metrics.

```ruby
ActiveReporting::Metric.new(
  ...,
  aggregate: :count_distinct,
  distinct_on: [:reservation_id],
  ...
)
```